### PR TITLE
Make addition semantic coherent for `DenseMultilinearExtension`

### DIFF
--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -1,4 +1,4 @@
-use core::ops::IndexMut;
+use core::{cmp::max, ops::IndexMut};
 
 use ark_ff::Zero;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -244,15 +244,16 @@ impl<'a, R: Ring> Add<&'a DenseMultilinearExtension<R>> for &DenseMultilinearExt
             "trying to add two dense MLEs with different numbers of variables"
         );
 
-        let self_evals = if self.evaluations.len() < rhs.evaluations.len() {
-            let mut evals = self.evaluations.clone();
-            evals.resize(rhs.evaluations.len(), R::zero());
-            Cow::Owned(evals)
-        } else {
-            Cow::Borrowed(&self.evaluations)
-        };
+        let max_len = max(self.evaluations.len(), rhs.evaluations.len());
+
+        let mut self_evals = self.evaluations.clone();
+        self_evals.resize(max_len, R::zero());
+
+        let mut rhs_evals = rhs.evaluations.clone();
+        rhs_evals.resize(max_len, R::zero());
+
         let result = cfg_iter!(self_evals)
-            .zip(cfg_iter!(rhs.evaluations))
+            .zip(cfg_iter!(rhs_evals))
             .map(|(a, b)| *a + b)
             .collect();
 


### PR DESCRIPTION
Problem: `add` and `add_assign` have different behaviour for the type `DenseMultilinearExtension`. 
Fix: change `add` semantic to make it match `add_assign`. 

Room for improvement: I'm not sure which function was correct in the first place. I assume `add_assign` was the correct one but someone should double-check. 
There might be optimizations on the memory side that can make this go faster. 

@v0-e This might be of interest for you.