### PR TITLE
CI nextest version pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       # use the more efficient nextest
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
       - uses: Swatinem/rust-cache@v2
       - name: Build
         # This build will be reused by nextest,


### PR DESCRIPTION
Workaround for https://github.com/taiki-e/install-action/issues/1005.