### PR TITLE
Matrix gadget decomposition, trait-based decomposition

### DIFF
--- a/ring/src/balanced_decomposition/convertible_ring.rs
+++ b/ring/src/balanced_decomposition/convertible_ring.rs
@@ -41,7 +41,7 @@ pub trait ConvertibleRing:
 }
 
 impl<R: ConvertibleRing> Decompose for R {
-    fn decompose_in_place(&self, b: u128, out: &mut [Self]) {
+    fn decompose_to(&self, b: u128, out: &mut [Self]) {
         decompose_balanced_in_place(self, b, out);
     }
 }

--- a/ring/src/balanced_decomposition/convertible_ring.rs
+++ b/ring/src/balanced_decomposition/convertible_ring.rs
@@ -40,25 +40,25 @@ pub trait ConvertibleRing:
         + Sized;
 }
 
-impl<R: ConvertibleRing> Decompose for R {
+impl<Z: ConvertibleRing> Decompose for Z {
     fn decompose_to(&self, b: u128, out: &mut [Self]) {
         decompose_balanced_in_place(self, b, out);
     }
 }
 
 // Norms
-impl<F: ConvertibleRing> WithL2Norm for F {
+impl<Z: ConvertibleRing> WithL2Norm for Z {
     fn l2_norm_squared(&self) -> BigUint {
-        let x: <F as ConvertibleRing>::SignedInt = (*self).into();
+        let x: <Z as ConvertibleRing>::SignedInt = (*self).into();
         let x: BigInt = x.into();
 
         x.pow(2).try_into().unwrap()
     }
 }
 
-impl<F: ConvertibleRing> WithLinfNorm for F {
+impl<Z: ConvertibleRing> WithLinfNorm for Z {
     fn linf_norm(&self) -> BigUint {
-        let x: <F as ConvertibleRing>::SignedInt = (*self).into();
+        let x: <Z as ConvertibleRing>::SignedInt = (*self).into();
         let x: BigInt = x.into();
 
         x.abs().to_biguint().unwrap()

--- a/ring/src/balanced_decomposition/mod.rs
+++ b/ring/src/balanced_decomposition/mod.rs
@@ -21,11 +21,11 @@ mod fq_convertible;
 pub(crate) mod representatives;
 
 pub trait Decompose: Sized + Zero + Copy {
-    fn decompose_in_place(&self, b: u128, out: &mut [Self]);
+    fn decompose_to(&self, b: u128, out: &mut [Self]);
     fn decompose(&self, b: u128, padding_size: usize) -> Vec<Self> {
         let mut res = vec![Self::zero(); padding_size];
 
-        self.decompose_in_place(b, &mut res);
+        self.decompose_to(b, &mut res);
 
         res
     }
@@ -101,7 +101,7 @@ pub fn gadget_decompose<R: Decompose + Sync + Send>(
 
     cfg_chunks_mut!(&mut out, padding_size)
         .zip(cfg_iter!(v_s))
-        .for_each(|(chunk_mut, v)| v.decompose_in_place(b, chunk_mut));
+        .for_each(|(chunk_mut, v)| v.decompose_to(b, chunk_mut));
 
     out
 }

--- a/ring/src/balanced_decomposition/mod.rs
+++ b/ring/src/balanced_decomposition/mod.rs
@@ -10,25 +10,39 @@ use num_traits::Signed;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use crate::{PolyRing, Ring};
+use crate::Ring;
 use convertible_ring::ConvertibleRing;
-use stark_rings_linalg::{
-    ops::{rounded_div, Transpose},
-    Matrix, SymmetricMatrix,
-};
+use stark_rings_linalg::{ops::rounded_div, Matrix, SymmetricMatrix};
 pub mod convertible_ring;
 mod fq_convertible;
 pub(crate) mod representatives;
 
-pub trait Decompose: Sized + Zero + Copy {
+/// Ring decomposition
+pub trait Decompose: Ring {
     fn decompose_to(&self, b: u128, out: &mut [Self]);
     fn decompose(&self, b: u128, padding_size: usize) -> Vec<Self> {
-        let mut res = vec![Self::zero(); padding_size];
-
-        self.decompose_to(b, &mut res);
-
-        res
+        let mut out = vec![Self::zero(); padding_size];
+        self.decompose_to(b, &mut out);
+        out
     }
+}
+
+/// Decompose to split vectors
+pub trait DecomposeToVec {
+    type Element;
+    fn decompose_to_vec(&self, b: u128, padding_size: usize) -> Vec<Self::Element>;
+}
+
+/// Decompose, creating an extended version
+pub trait GadgetDecompose {
+    type Output;
+    fn gadget_decompose(&self, b: u128, padding_size: usize) -> Self::Output;
+}
+
+/// Recompose
+pub trait GadgetRecompose {
+    type Output;
+    fn gadget_recompose(&self, b: u128, padding_size: usize) -> Self::Output;
 }
 
 /// Returns the balanced decomposition of a slice as a Vec of Vecs.
@@ -41,7 +55,7 @@ pub trait Decompose: Sized + Zero + Copy {
 /// # Output
 /// Returns `d`, the decomposition in basis `b` as a Vec of size `decomp_size`, i.e.,
 /// $\texttt{v}\[i\] = \sum_{j \in \[k\]} \texttt{b}^j \texttt{d}\[j\]$ and $|\texttt{d}\[j\]| \leq \left\lfloor\frac{\texttt{b}}{2}\right\rfloor$.
-pub fn decompose_balanced_in_place<R: ConvertibleRing>(v: &R, b: u128, out: &mut [R]) {
+pub fn decompose_balanced_in_place<Z: ConvertibleRing>(v: &Z, b: u128, out: &mut [Z]) {
     assert!(
         !b.is_zero() && !b.is_one(),
         "cannot decompose in basis 0 or 1"
@@ -49,7 +63,7 @@ pub fn decompose_balanced_in_place<R: ConvertibleRing>(v: &R, b: u128, out: &mut
     // TODO: not sure if this really necessary, but having b be even allow for more efficient divisions/remainders
     assert_eq!(b % 2, 0, "decomposition basis must be even");
 
-    let mut curr = Into::<R::SignedInt>::into(*v);
+    let mut curr = Into::<Z::SignedInt>::into(*v);
     let mut current_i = 0;
     let b = b as i128;
     let b_half_floor = b.div_euclid(2);
@@ -58,14 +72,14 @@ pub fn decompose_balanced_in_place<R: ConvertibleRing>(v: &R, b: u128, out: &mut
 
         // Ensure digit is in [-b/2, b/2]
         if rem.abs() <= b_half_floor.into() {
-            out[current_i] = Into::<R>::into(rem);
+            out[current_i] = Into::<Z>::into(rem);
             curr /= b; // Rust integer division rounds towards zero
         } else {
             // The next element in the decomposition is sign(rem) * (|rem| - b)
             if rem < 0.into() {
-                out[current_i] = Into::<R>::into(rem.clone() + b);
+                out[current_i] = Into::<Z>::into(rem.clone() + b);
             } else {
-                out[current_i] = Into::<R>::into(rem.clone() - b);
+                out[current_i] = Into::<Z>::into(rem.clone() - b);
             }
             let carry = rounded_div(rem, b); // Round toward nearest integer, not towards 0
             curr = (curr / b) + carry;
@@ -79,128 +93,8 @@ pub fn decompose_balanced_in_place<R: ConvertibleRing>(v: &R, b: u128, out: &mut
     }
 
     for out_tail_elem in out[current_i..].iter_mut() {
-        *out_tail_elem = R::zero();
+        *out_tail_elem = Z::zero();
     }
-}
-
-pub fn decompose_balanced<R: ConvertibleRing>(v: &R, b: u128, padding_size: usize) -> Vec<R> {
-    let mut out = vec![R::zero(); padding_size];
-
-    decompose_balanced_in_place(v, b, &mut out);
-
-    out
-}
-
-pub fn gadget_decompose<R: Decompose + Sync + Send>(
-    v_s: &[R],
-    b: u128,
-    // Padding size is the maximum power of the gadget matrix
-    padding_size: usize,
-) -> Vec<R> {
-    let mut out = vec![R::zero(); padding_size * v_s.len()];
-
-    cfg_chunks_mut!(&mut out, padding_size)
-        .zip(cfg_iter!(v_s))
-        .for_each(|(chunk_mut, v)| v.decompose_to(b, chunk_mut));
-
-    out
-}
-
-pub fn gadget_recompose<A, B>(
-    v_s: &[A],
-    b: B,
-    // Padding size is the maximum power of the gadget matrix
-    padding_size: usize,
-) -> Vec<A>
-where
-    A: Zero + Copy + for<'a> MulAssign<&'a B> + for<'a> AddAssign<&'a A> + Sync + Send,
-    B: Copy + Sync + Send,
-{
-    let mut out = vec![A::zero(); v_s.len() / padding_size];
-
-    cfg_chunks!(v_s, padding_size)
-        .zip(cfg_iter_mut!(out))
-        .for_each(|(chunk, v)| *v = recompose(chunk, b));
-
-    out
-}
-
-/// Returns the balanced decomposition of a slice as a Vec of Vecs.
-///
-/// # Arguments
-/// * `v`: input slice, of length `l`
-/// * `b`: basis for the decomposition, must be even
-/// * `padding_size`: indicates whether the output should be padded with zeros to a specified length `k` if `padding_size` is `Some(k)`, or if it should be padded to the largest decomposition length required for `v` if `padding_size` is `None`
-///
-/// # Output
-/// Returns `d` the decomposition in basis `b` as a Vec of size `decomp_size`, with each item being a Vec of length `l`, i.e.,
-/// for all $i \in \[l\]: \texttt{v}\[i\] = \sum_{j \in \[k\]} \texttt{b}^j \texttt{d}\[i\]\[j\]$ and $|\texttt{d}\[i\]\[j\]| \leq \left\lfloor\frac{\texttt{b}}{2}\right\rfloor$.
-pub fn decompose_balanced_vec<D: Ring + Decompose>(
-    v: &[D],
-    b: u128,
-    padding_size: usize,
-) -> Vec<Vec<D>> {
-    cfg_iter!(v)
-        .map(|v_i| v_i.decompose(b, padding_size))
-        .collect()
-}
-
-/// Returns the balanced decomposition of a [`PolyRing`] element as a Vec of [`PolyRing`] elements.
-///
-/// # Arguments
-/// * `v`: `PolyRing` element to be decomposed
-/// * `b`: basis for the decomposition, must be even
-/// * `padding_size`: indicates whether the output should be padded with zeros to a specified length `k` if `padding_size` is `Some(k)`, or if it should be padded to the largest decomposition length required for `v` if `padding_size` is `None`
-///
-/// # Output
-/// Returns `d` the decomposition in basis `b` as a Vec of size `decomp_size`, i.e.,
-/// for all $\texttt{v} = \sum_{j \in \[k\]} \texttt{b}^j \texttt{d}\[j\]$ and $|\texttt{d}\[j\]| \leq \left\lfloor\frac{\texttt{b}}{2}\right\rfloor$.
-pub fn decompose_balanced_polyring<R: PolyRing>(v: &R, b: u128, padding_size: usize) -> Vec<R>
-where
-    R::BaseRing: Decompose,
-{
-    decompose_balanced_vec::<R::BaseRing>(v.coeffs(), b, padding_size)
-        .transpose()
-        .into_iter()
-        .map(|v_i| R::from(v_i))
-        .collect()
-}
-
-pub fn decompose_balanced_slice_polyring<R: PolyRing>(
-    v: &[R],
-    b: u128,
-    padding_size: usize,
-) -> Vec<Vec<R>>
-where
-    R::BaseRing: Decompose,
-{
-    cfg_iter!(v)
-        .map(|ring_elem| decompose_balanced_polyring(ring_elem, b, padding_size))
-        .collect()
-}
-
-/// Returns the balanced decomposition of a slice of [`PolyRing`] elements as a Vec of [`Vector`] of [`PolyRing`] elements.
-///
-/// # Arguments
-/// * `v`: input slice, of length `l`
-/// * `b`: basis for the decomposition, must be even
-/// * `padding_size`: indicates whether the output should be padded with zeros to a specified length `k` if `padding_size` is `Some(k)`, or if it should be padded to the largest decomposition length required for `v` if `padding_size` is `None`
-///
-/// # Output
-/// Returns `d` the decomposition in basis `b` as a Vec of size `decomp_size`, with each item being a Vec of length `l`, i.e.,
-/// for all $i \in \[l\]: \texttt{v}\[i\] = \sum_{j \in \[k\]} \texttt{b}^j \texttt{d}\[i\]\[j\]$ and $|\texttt{d}\[i\]\[j\]| \leq \left\lfloor\frac{\texttt{b}}{2}\right\rfloor$.
-pub fn decompose_balanced_vec_polyring<R: PolyRing>(
-    v: &Vec<R>,
-    b: u128,
-    padding_size: usize,
-) -> Vec<Vec<R>>
-where
-    R::BaseRing: Decompose,
-{
-    cfg_iter!(v.as_slice())
-        .map(|ring_elem| decompose_balanced_polyring(ring_elem, b, padding_size))
-        .map(Vec::from)
-        .collect()
 }
 
 pub fn recompose<A, B>(v: &[A], b: B) -> A
@@ -215,6 +109,115 @@ where
     }
 
     result
+}
+
+impl<R: Decompose> DecomposeToVec for &[R] {
+    type Element = Vec<R>;
+    /// Returns the balanced decomposition of a slice as a Vec of Vecs.
+    ///
+    /// # Arguments
+    /// * `v`: input slice, of length `l`
+    /// * `b`: basis for the decomposition, must be even
+    /// * `padding_size`: indicates whether the output should be padded with zeros to a specified length `k` if `padding_size` is `Some(k)`, or if it should be padded to the largest decomposition length required for `v` if `padding_size` is `None`
+    ///
+    /// # Output
+    /// Returns `d` the decomposition in basis `b` as a Vec of size `decomp_size`, with each item being a Vec of length `l`, i.e.,
+    fn decompose_to_vec(&self, b: u128, padding_size: usize) -> Vec<Vec<R>> {
+        cfg_iter!(self)
+            .map(|v_i| v_i.decompose(b, padding_size))
+            .collect()
+    }
+}
+
+impl<R: Decompose> DecomposeToVec for Vec<R> {
+    type Element = Vec<R>;
+    /// Returns the balanced decomposition of a slice as a Vec of Vecs.
+    ///
+    /// # Arguments
+    /// * `v`: input slice, of length `l`
+    /// * `b`: basis for the decomposition, must be even
+    /// * `padding_size`: indicates whether the output should be padded with zeros to a specified length `k` if `padding_size` is `Some(k)`, or if it should be padded to the largest decomposition length required for `v` if `padding_size` is `None`
+    ///
+    /// # Output
+    /// Returns `d` the decomposition in basis `b` as a Vec of size `decomp_size`, with each item being a Vec of length `l`, i.e.,
+    fn decompose_to_vec(&self, b: u128, padding_size: usize) -> Vec<Vec<R>> {
+        self.as_slice().decompose_to_vec(b, padding_size)
+    }
+}
+
+impl<R: Decompose> GadgetDecompose for &[R] {
+    type Output = Vec<R>;
+
+    fn gadget_decompose(&self, b: u128, padding_size: usize) -> Vec<R> {
+        let mut out = vec![R::zero(); padding_size * self.len()];
+
+        cfg_chunks_mut!(&mut out, padding_size)
+            .zip(cfg_iter!(self))
+            .for_each(|(chunk_mut, v)| v.decompose_to(b, chunk_mut));
+
+        out
+    }
+}
+
+impl<R: Ring> GadgetRecompose for &[R] {
+    type Output = Vec<R>;
+
+    fn gadget_recompose(&self, b: u128, padding_size: usize) -> Vec<R> {
+        let mut out = vec![R::zero(); self.len() / padding_size];
+        let b = R::from(b);
+
+        cfg_chunks!(self, padding_size)
+            .zip(cfg_iter_mut!(out))
+            .for_each(|(chunk, v)| *v = recompose(chunk, b));
+
+        out
+    }
+}
+
+impl<R: Decompose> GadgetDecompose for Vec<R> {
+    type Output = Vec<R>;
+
+    fn gadget_decompose(&self, b: u128, padding_size: usize) -> Vec<R> {
+        self.as_slice().gadget_decompose(b, padding_size)
+    }
+}
+
+impl<R: Ring> GadgetRecompose for Vec<R> {
+    type Output = Vec<R>;
+
+    fn gadget_recompose(&self, b: u128, padding_size: usize) -> Vec<R> {
+        self.as_slice().gadget_recompose(b, padding_size)
+    }
+}
+
+impl<R: Decompose> GadgetDecompose for Matrix<R> {
+    type Output = Matrix<R>;
+
+    /// Returns the balanced gadget decomposition of a [`Matrix`] of dimensions `n × m` as a matrix of dimensions `n × (k × m)`.
+    ///
+    /// # Arguments
+    /// * `mat`: input matrix of dimensions `n × m`
+    /// * `b`: basis for the decomposition, must be even
+    /// * `padding_size`: indicates whether the decomposition length is the specified `k` if `padding_size` is `Some(k)`, or if `k` is the largest decomposition length required for `mat` if `padding_size` is `None`
+    ///
+    /// # Output
+    /// Returns `d` the decomposition in basis `b` as a Matrix of dimensions `n × (k × m)`, i.e.,
+    fn gadget_decompose(&self, b: u128, padding_size: usize) -> Matrix<R> {
+        cfg_iter!(self.vals)
+            .map(|row| row.as_slice().gadget_decompose(b, padding_size))
+            .collect::<Vec<_>>()
+            .into()
+    }
+}
+
+impl<R: Ring> GadgetRecompose for Matrix<R> {
+    type Output = Matrix<R>;
+    fn gadget_recompose(&self, b: u128, padding_size: usize) -> Matrix<R> {
+        cfg_iter!(self.vals)
+            .map(|row| row.as_slice().gadget_recompose(b, padding_size))
+            .collect::<Vec<_>>()
+            .into()
+    }
 }
 
 /// Given a `n*d x n*d` symmetric matrix `mat` and a slice `\[1, b, ..., b^(d-1)\]` `powers_of_basis`, returns the `n x n` symmetric matrix corresponding to $G^T \textt{mat} G$, where $G = I_n \otimes (1, b, ..., b^(\textt{d}-1))$ is the gadget matrix of dimensions `n*d x n`.
@@ -248,42 +251,11 @@ where
         .into()
 }
 
-/// Returns the balanced gadget decomposition of a [`Matrix`] of dimensions `n × m` as a matrix of dimensions `n × (k * m)`.
-///
-/// # Arguments
-/// * `mat`: input matrix of dimensions `n × m`
-/// * `b`: basis for the decomposition, must be even
-/// * `padding_size`: indicates whether the decomposition length is the specified `k` if `padding_size` is `Some(k)`, or if `k` is the largest decomposition length required for `mat` if `padding_size` is `None`
-///
-/// # Output
-/// Returns `d` the decomposition in basis `b` as a Matrix of dimensions `n × (k * m)`, i.e.,
-pub fn decompose_matrix<F: Decompose + Sized + Sync + Send>(
-    mat: &Matrix<F>,
-    decomposition_basis: u128,
-    decomposition_length: usize,
-) -> Matrix<F> {
-    let row_iter = {
-        #[cfg(not(feature = "parallel"))]
-        {
-            mat.vals.iter()
-        }
-        #[cfg(feature = "parallel")]
-        {
-            mat.vals.par_iter()
-        }
-    };
-    row_iter
-        .map(|s_i| gadget_decompose(s_i, decomposition_basis, decomposition_length))
-        .collect::<Vec<_>>()
-        .into()
-}
-
 #[cfg(test)]
 mod tests {
     use crate::cyclotomic_ring::models::goldilocks::{Fq, RqPoly};
-
-    use crate::PolyRing;
-    use crate::SignedRepresentative;
+    use crate::{PolyRing, SignedRepresentative};
+    use stark_rings_linalg::ops::Transpose;
 
     use super::*;
 
@@ -300,7 +272,7 @@ mod tests {
         for b in BASIS_TEST_RANGE {
             let b_half = R::from(b / 2);
             for v in &vs {
-                let decomp = decompose_balanced(v, b, 32);
+                let decomp = v.decompose(b, 32);
 
                 // Check that all entries are smaller than b/2
                 for v_i in &decomp {
@@ -322,7 +294,7 @@ mod tests {
         let v = get_test_vec();
         for b in BASIS_TEST_RANGE {
             let b_half = b / 2;
-            let decomp = decompose_balanced_vec(&v, b, 16).transpose();
+            let decomp = v.decompose_to_vec(b, 16).transpose();
 
             // Check that all entries are smaller than b/2 in absolute value
             for d_i in &decomp {
@@ -345,7 +317,7 @@ mod tests {
         let v: PolyR = PolyR::from(get_test_vec());
         for b in BASIS_TEST_RANGE {
             let b_half = b / 2;
-            let decomp = decompose_balanced_polyring(&v, b, 16);
+            let decomp = v.decompose(b, 16);
 
             for d_i in &decomp {
                 for &d_ij in d_i.coeffs() {
@@ -367,7 +339,7 @@ mod tests {
             RqPoly::from((0..24).map(|_| Fq::from(-15)).collect::<Vec<Fq>>()),
         ];
 
-        let decomposed = gadget_decompose(&vec, 2, 4);
+        let decomposed = vec.gadget_decompose(2, 4);
         let expected = vec![
             RqPoly::from((0..24).map(|_| Fq::from(1)).collect::<Vec<Fq>>()),
             RqPoly::from((0..24).map(|_| Fq::from(1)).collect::<Vec<Fq>>()),
@@ -402,11 +374,11 @@ mod tests {
             RqPoly::from((0..24).map(|_| Fq::from(-1)).collect::<Vec<Fq>>()),
         ];
 
-        assert_eq!(gadget_recompose(&decomposed, 2u128, 4), expected);
+        assert_eq!(decomposed.gadget_recompose(2u128, 4), expected);
     }
 
     #[test]
-    fn test_gadget_matrix_decompose() {
+    fn test_matrix_gadget_decompose() {
         use crate::cyclotomic_ring::models::goldilocks::{Fq, RqPoly};
 
         let m: Matrix<RqPoly> = vec![
@@ -421,7 +393,7 @@ mod tests {
         ]
         .into();
 
-        let decomposed = decompose_matrix(&m, 2, 4);
+        let decomposed = m.gadget_decompose(2, 4);
         let expected = vec![
             vec![
                 RqPoly::from((0..24).map(|_| Fq::from(1)).collect::<Vec<Fq>>()),
@@ -446,5 +418,27 @@ mod tests {
         ];
 
         assert_eq!(decomposed, expected.into());
+    }
+
+    #[test]
+    fn test_matrix_gadget_recompose() {
+        use crate::cyclotomic_ring::models::goldilocks::{Fq, RqPoly};
+
+        let m: Matrix<RqPoly> = vec![
+            vec![
+                RqPoly::from((0..24).map(|_| Fq::from(15)).collect::<Vec<Fq>>()),
+                RqPoly::from((0..24).map(|_| Fq::from(-15)).collect::<Vec<Fq>>()),
+            ],
+            vec![
+                RqPoly::from((0..24).map(|_| Fq::from(15)).collect::<Vec<Fq>>()),
+                RqPoly::from((0..24).map(|_| Fq::from(-15)).collect::<Vec<Fq>>()),
+            ],
+        ]
+        .into();
+
+        let decomposed = m.gadget_decompose(2, 4);
+        let recomposed = decomposed.gadget_recompose(2, 4);
+
+        assert_eq!(recomposed, m);
     }
 }

--- a/ring/src/cyclotomic_ring/coeff_form.rs
+++ b/ring/src/cyclotomic_ring/coeff_form.rs
@@ -589,11 +589,11 @@ impl<C: CyclotomicConfig<N>, const N: usize, const D: usize> Decompose
 where
     Fp<C::BaseFieldConfig, N>: Decompose,
 {
-    fn decompose_in_place(&self, b: u128, out: &mut [Self]) {
+    fn decompose_to(&self, b: u128, out: &mut [Self]) {
         let mut buffer = vec![Fp::<C::BaseFieldConfig, N>::zero(); out.len()];
 
         for (i, coeff) in self.0.iter().enumerate() {
-            coeff.decompose_in_place(b, &mut buffer);
+            coeff.decompose_to(b, &mut buffer);
 
             out.iter_mut()
                 .zip(buffer.iter())


### PR DESCRIPTION
Adds `Matrix` gadget re/decomposition.
Also moves the decomposition fn-based implementation to a more trait-based one.